### PR TITLE
Added the 'alternate' property

### DIFF
--- a/pub-context.jsonld
+++ b/pub-context.jsonld
@@ -17,7 +17,7 @@
             "@language": null
         },
         "alternate": {
-            "@container": "@list",
+            "@container": "@set",
             "@type" : "@id",
             "@id": "https://www.w3.org/ns/pub#alternate"
         },

--- a/pub-context.jsonld
+++ b/pub-context.jsonld
@@ -16,6 +16,11 @@
             "@id" : "https://schema.org/accessibilityHazard",
             "@language": null
         },
+        "alternate": {
+            "@container": "@list",
+            "@type" : "@id",
+            "@id": "https://www.w3.org/ns/pub#alternate"
+        },
         "artist": {
             "@container": "@list",
             "@id": "https://schema.org/artist"

--- a/pub.jsonld
+++ b/pub.jsonld
@@ -50,6 +50,13 @@
             "rdfs:label": "List of extra resources"
         },
         {
+            "@id": "pub:alternate",
+            "@type": "rdf:Property",
+            "rdfs:comment": "References to one or more reformulation(s) of the resource in alternative formats",
+            "rdfs:isDefinedBy": "https://www.w3.org/TR/pub-manifest/#linkedResource",
+            "rdfs:label": "Alternative formats"
+        },
+        {
             "@id": "pub:readingOrder",
             "@type": "rdf:Property",
             "rdfs:comment": "The default reading order is a specific progression through a set of Publication resources.",

--- a/pub.rdf
+++ b/pub.rdf
@@ -39,8 +39,14 @@
   
   <rdf:Property rdf:about="https://www.w3.org/ns/pub#links">
     <rdfs:comment>The list of extra resources enumerates all resources that are used in the processing and rendering of a Publication but are not within its bounds (i.e., are not listed in the default reading order or the resource list) but are, rather, external to the Publication.</rdfs:comment>
-    <rdfs:isDefinedBy rdf:resource="https://www.w3.org/TR/pub-manifest/#links"/>
+    <rdfs:isDefinedBy rdf:resource="https://www.w3.org/TR/pub-manifest/#linkedResource"/>
     <rdfs:label>List of extra resources</rdfs:label>
+  </rdf:Property>
+
+  <rdf:Property rdf:about="https://www.w3.org/ns/pub#alternate">
+    <rdfs:comment>References to one or more reformulation(s) of the resource in alternative formats</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="https://www.w3.org/TR/pub-manifest/#links"/>
+    <rdfs:label>Alternative formats</rdfs:label>
   </rdf:Property>
 
   <rdf:Property rdf:about="https://www.w3.org/ns/pub#resources">

--- a/pub.ttl
+++ b/pub.ttl
@@ -35,6 +35,11 @@ pub:links a rdf:Property ;
 	rdfs:comment "The list of extra resources enumerates all resources that are used in the processing and rendering of a Publication but are not within its bounds (i.e., are not listed in the default reading order or the resource list) but are, rather, external to the Publication." ;
 	rdfs:isDefinedBy <https://www.w3.org/TR/pub-manifest/#links> .
 
+pub:alternate a rdf:Property ;
+	rdfs:label "Alternative formats" ;
+	rdfs:comment "References to one or more reformulation(s) of the resource in alternative formats." ;
+	rdfs:isDefinedBy <https://www.w3.org/TR/pub-manifest/#linkedResource> .
+
 pub:LinkedResource a rdfs:Class ;
 	rdfs:label "General type used for resources linked from the manifest." ;
 	rdfs:comment "General type used for resources linked from the manifest." ;


### PR DESCRIPTION
This is the PR corresponding to https://github.com/w3c/pub-manifest/pull/56.

At the moment, this presupposes that the order in the list of alternates is significant (see https://github.com/w3c/pub-manifest/pull/56#discussion_r322061410). If the decision is 'no', then this must be changed (the value of `"@container"` must be `"@set"`, instead of `"@list"`).

Cc @marisademeglio 