### PR TITLE
Removed the 'length' value in favour of duration.

### DIFF
--- a/pub-context-jsonld10.jsonld
+++ b/pub-context-jsonld10.jsonld
@@ -83,10 +83,6 @@
             "@container": "@list",
             "@id": "https://schema.org/letterer"
         },
-        "length": {
-            "@type": "xsd:double",
-            "@id": "https://www.w3.org/ns/pub#length"
-        },
         "links": {
             "@container": "@set",
             "@type" : "@id",

--- a/pub-context.jsonld
+++ b/pub-context.jsonld
@@ -93,10 +93,6 @@
             "@container": "@list",
             "@id": "https://schema.org/letterer"
         },
-        "length": {
-            "@type": "xsd:double",
-            "@id": "https://www.w3.org/ns/pub#length"
-        },
         "links": {
             "@container": "@set",
             "@type" : "@id",

--- a/pub.jsonld
+++ b/pub.jsonld
@@ -71,13 +71,6 @@
             "rdfs:label": "Resource list"
         },
         {
-            "@id": "pub:length",
-            "@type": "rdf:Property",
-            "rdfs:comment": "The total length of a time-based media resource in (possibly fractional) seconds.",
-            "rdfs:isDefinedBy": "https://www.w3.org/TR/pub-manifest/#linkedResource",
-            "rdfs:label": "Resource level length"
-        },
-        {
             "@id": "pub:integrity",
             "@type": "rdf:Property",
             "rdfs:comment": "A cryptographic hashing of the resource that allows its integrity to be verified.",

--- a/pub.rdf
+++ b/pub.rdf
@@ -25,12 +25,6 @@
     <rdfs:label>Default reading order</rdfs:label>
   </rdf:Property>
 
-  <rdf:Property rdf:about="https://www.w3.org/ns/pub#length">
-    <rdfs:label>Resource level length</rdfs:label>
-    <rdfs:comment>The total length of a time-based media resource in (possibly fractional) seconds.</rdfs:comment>
-    <rdfs:isDefinedBy rdf:resource="https://www.w3.org/TR/pub-manifest/#linkedResource"/>
-  </rdf:Property>
-
   <rdf:Property rdf:about="https://www.w3.org/ns/pub#integrity">
     <rdfs:label>Resource integrity</rdfs:label>
     <rdfs:comment>A cryptographic hashing of the resource that allows its integrity to be verified.</rdfs:comment>

--- a/pub.ttl
+++ b/pub.ttl
@@ -45,11 +45,6 @@ pub:rel a rdf:Property ;
 	rdfs:comment "Equivalent to the rel attribute in HTML; uses either the IANA link registry data, or specially minted URL-s." ;
 	rdfs:isDefinedBy <https://www.w3.org/TR/pub-manifest/#linkedResource> .
 
-pub:length a rdf:Property ;
-	rdfs:label "Resource level length" ;
-	rdfs:comment "The total length of a time-based media resource in (possibly fractional) seconds." ;
-	rdfs:isDefinedBy <https://www.w3.org/TR/pub-manifest/#linkedResource> .
-
 pub:integrity a rdf:Property ;
 	rdfs:label "Resource integrity" ;
 	rdfs:comment "A cryptographic hashing of the resource that allows its integrity to be verified." ;


### PR DESCRIPTION
This is synced to https://github.com/w3c/pub-manifest/pull/164 (removing `length` in favor of `duration` everywhere).